### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -71,7 +71,7 @@ def parse_global_section(config):
             pass
 
     if debug:
-        print "=== begin section\n%s\n=== end section" % tmp
+        print "=== begin section\n{0!s}\n=== end section".format(tmp)
 
     return tmp
 
@@ -87,13 +87,13 @@ def parse_vpn_section(config, section):
         try:
             tmp[option] = config.get(section, option)
             if tmp[option] == -1:
-                print('CONFIG: skipping %s' % option)
+                print('CONFIG: skipping {0!s}'.format(option))
         except:
-            print('CONFIG: exception on %s' % option)
+            print('CONFIG: exception on {0!s}'.format(option))
             tmp[option] = None
 
     if debug:
-        print "=== begin section\n%s\n=== end section" % tmp
+        print "=== begin section\n{0!s}\n=== end section".format(tmp)
 
     return tmp
 
@@ -127,7 +127,7 @@ def openvpn_connect(vpn, command):
     s.close()
 
     if debug:
-        print "=== begin raw data\n%s\n=== end raw data" % data
+        print "=== begin raw data\n{0!s}\n=== end raw data".format(data)
 
     return data
 
@@ -141,7 +141,7 @@ def openvpn_parse_state(data):
     for line in data.splitlines():
         tmp = line.split(',')
         if debug:
-            print "=== begin split line\n%s\n=== end split line" % tmp
+            print "=== begin split line\n{0!s}\n=== end split line".format(tmp)
         if tmp[0].startswith('>INFO') or \
            tmp[0].startswith('END') or \
            tmp[0].startswith('>CLIENT'):
@@ -171,7 +171,7 @@ def openvpn_parse_stats(data):
     tmp = line.split(',')
 
     if debug:
-        print "=== begin split line\n%s\n=== end split line" % tmp
+        print "=== begin split line\n{0!s}\n=== end split line".format(tmp)
 
     stats['nclients'] = re.sub('nclients=', '', tmp[0])
     stats['bytesin'] = re.sub('bytesin=', '', tmp[1])
@@ -199,7 +199,7 @@ def openvpn_parse_status(data):
             tmp = line.split('\t')
 
         if debug:
-            print "=== begin split line\n%s\n=== end split line" % tmp
+            print "=== begin split line\n{0!s}\n=== end split line".format(tmp)
 
         if tmp[0].startswith('GLOBAL'):
             break
@@ -280,7 +280,7 @@ def openvpn_parse_status(data):
                 sessions[tmp[3]]['last_seen'] = get_date(tmp[4])
 
     if debug and sessions:
-        print "=== begin sessions\n%s\n=== end sessions" % sessions
+        print "=== begin sessions\n{0!s}\n=== end sessions".format(sessions)
 
     return sessions
 
@@ -290,7 +290,7 @@ def connection_table_headers(headers):
     print '<table class="table table-striped table-bordered table-hover table-condensed table-responsive">'
     print '<thead><tr>'
     for header in headers:
-        print '<th>%s</th>' % header
+        print '<th>{0!s}</th>'.format(header)
     print '</tr></thead><tbody>'
 
 
@@ -311,9 +311,9 @@ def openvpn_print_html(vpn):
     remote_ip = vpn['state']['remote_ip']
 
     anchor = vpn['name'].lower().replace(' ', '_')
-    print '<div class="panel panel-success" id="%s">' % anchor
-    print '<div class="panel-heading"><h3 class="panel-title">%s</h3>' % \
-        vpn['name']
+    print '<div class="panel panel-success" id="{0!s}">'.format(anchor)
+    print '<div class="panel-heading"><h3 class="panel-title">{0!s}</h3>'.format( \
+        vpn['name'])
     print '</div><div class="panel-body">'
     print '<table class="table table-condensed table-responsive">'
     print '<thead><tr><th>VPN Type</th><th>Status</th><th>Pingable</th>'
@@ -322,15 +322,15 @@ def openvpn_print_html(vpn):
     if vpn_type == 'tap':
         print '<th>Remote IP Address</th>'
     print '</tr></thead><tbody>'
-    print '<tr><td>%s</td>' % vpn_type
-    print '<td>%s</td>' % connection
-    print '<td>%s</td>' % pingable
-    print '<td>%s</td>' % nclients
-    print '<td>%s</td>' % bytesin
-    print '<td>%s</td>' % bytesout
-    print '<td>%s</td>' % local_ip
+    print '<tr><td>{0!s}</td>'.format(vpn_type)
+    print '<td>{0!s}</td>'.format(connection)
+    print '<td>{0!s}</td>'.format(pingable)
+    print '<td>{0!s}</td>'.format(nclients)
+    print '<td>{0!s}</td>'.format(bytesin)
+    print '<td>{0!s}</td>'.format(bytesout)
+    print '<td>{0!s}</td>'.format(local_ip)
     if vpn_type == 'tap':
-        print '<td>%s</td>' % remote_ip
+        print '<td>{0!s}</td>'.format(remote_ip)
     print '</tr></tbody></table>'
 
     tun_headers = ['Username / Hostname', 'VPN IP Address',
@@ -347,42 +347,41 @@ def openvpn_print_html(vpn):
     for key, session in vpn_sessions.items():
         print '<tr>'
         if vpn_type == 'tap':
-            print '<td>%s</td>' % locale.format('%d', int(session['tuntap_read']), True)
-            print '<td>%s</td>' % locale.format('%d', int(session['tuntap_write']), True)
-            print '<td>%s</td>' % locale.format('%d', int(session['tcpudp_read']), True)
-            print '<td>%s</td>' % locale.format('%d', int(session['tcpudp_write']), True)
-            print '<td>%s</td>' % locale.format('%d', int(session['auth_read']), True)
+            print '<td>{0!s}</td>'.format(locale.format('%d', int(session['tuntap_read']), True))
+            print '<td>{0!s}</td>'.format(locale.format('%d', int(session['tuntap_write']), True))
+            print '<td>{0!s}</td>'.format(locale.format('%d', int(session['tcpudp_read']), True))
+            print '<td>{0!s}</td>'.format(locale.format('%d', int(session['tcpudp_write']), True))
+            print '<td>{0!s}</td>'.format(locale.format('%d', int(session['auth_read']), True))
         else:
             total_time = str(datetime.now() - session['connected_since'])[:-7]
             bytes_recv = int(session['bytes_recv'])
             bytes_sent = int(session['bytes_sent'])
-            print '<td>%s</td>' % session['username']
+            print '<td>{0!s}</td>'.format(session['username'])
 
             if 'local_ip' in session:
-                print '<td>%s</td>' % session['local_ip']
+                print '<td>{0!s}</td>'.format(session['local_ip'])
             else:
                 print '<td>ERROR</td>'
-            print '<td>%s</td>' % session['remote_ip']
-            print '<td>%s</td>' % session['port']
+            print '<td>{0!s}</td>'.format(session['remote_ip'])
+            print '<td>{0!s}</td>'.format(session['port'])
 
             if 'city' in session and 'country_name' in session:
                 country = session['country_name']
                 city = session['city']
-                flag = 'flags/%s.png' % session['country'].lower()
-                print '<td><img src="%s" title="%s, %s" alt="%s" />' % \
-                    (flag, city, country, country)
-                print ' %s, %s</td>' % (city, country)
+                flag = 'flags/{0!s}.png'.format(session['country'].lower())
+                print '<td><img src="{0!s}" title="{1!s}, {2!s}" alt="{3!s}" />'.format(flag, city, country, country)
+                print ' {0!s}, {1!s}</td>'.format(city, country)
             else:
-                print '<td>%s</td>' % session['country']
+                print '<td>{0!s}</td>'.format(session['country'])
 
-            print '<td>%s</td>' % locale.format('%d', bytes_recv, True)
-            print '<td>%s</td>' % locale.format('%d', bytes_sent, True)
-            print '<td>%s</td>' % str(session['connected_since'].strftime('%d/%m/%Y %H:%M:%S'))
+            print '<td>{0!s}</td>'.format(locale.format('%d', bytes_recv, True))
+            print '<td>{0!s}</td>'.format(locale.format('%d', bytes_sent, True))
+            print '<td>{0!s}</td>'.format(str(session['connected_since'].strftime('%d/%m/%Y %H:%M:%S')))
             if 'last_seen' in session:
-                print '<td>%s</td>' % str(session['last_seen'].strftime('%d/%m/%Y %H:%M:%S'))
+                print '<td>{0!s}</td>'.format(str(session['last_seen'].strftime('%d/%m/%Y %H:%M:%S')))
             else:
                 print '<td>ERROR</td>'
-            print '<td>%s</td>' % total_time
+            print '<td>{0!s}</td>'.format(total_time)
         print '</tr>'
     print '</tbody></table></div></div>'
 
@@ -399,15 +398,13 @@ def google_maps_js(vpns, loc_lat, loc_long):
         if 'sessions' in vpn:
             for skey, session in vpn['sessions'].items():
                 if 'longitude' in session and 'latitude' in session:
-                    print 'var latlng = new google.maps.LatLng(%s, %s);' % \
-                        (session['latitude'], session['longitude'])
+                    print 'var latlng = new google.maps.LatLng({0!s}, {1!s});'.format(session['latitude'], session['longitude'])
                     print 'bounds.extend(latlng);'
-                    print 'markers.push(new google.maps.Marker({position: latlng, title: "%s - %s"}));' % \
-                        (session['username'], session['remote_ip'])
+                    print 'markers.push(new google.maps.Marker({{position: latlng, title: "{0!s} - {1!s}"}}));'.format(session['username'], session['remote_ip'])
                     sessions = sessions + 1
     if sessions != 0:
         if sessions == 1:
-            print 'bounds.extend(new google.maps.LatLng(%s, %s));' % (loc_lat, loc_long)
+            print 'bounds.extend(new google.maps.LatLng({0!s}, {1!s}));'.format(loc_lat, loc_long)
         print 'var myOptions = { zoom: 8, mapTypeId: google.maps.MapTypeId.ROADMAP };'
         print 'var map = new google.maps.Map(document.getElementById("map_canvas"), myOptions);'
         print 'map.fitBounds(bounds);'
@@ -415,7 +412,7 @@ def google_maps_js(vpns, loc_lat, loc_long):
         print '}'
         print '</script>'
     else:
-        print 'var latlng = new google.maps.LatLng(%s, %s);' % (loc_lat, loc_long)
+        print 'var latlng = new google.maps.LatLng({0!s}, {1!s});'.format(loc_lat, loc_long)
         print 'var myOptions = { zoom: 8, center: latlng, mapTypeId: google.maps.MapTypeId.ROADMAP };'
         print 'var map = new google.maps.Map(document.getElementById("map_canvas"), myOptions);'
         print '}'
@@ -446,7 +443,7 @@ def html_header(settings, vpns, maps):
     print '<meta charset="utf-8">'
     print '<meta http-equiv="X-UA-Compatible" content="IE=edge">'
     print '<meta name="viewport" content="width=device-width, initial-scale=1">'
-    print '<title>%s OpenVPN Status Monitor</title>' % settings['site']
+    print '<title>{0!s} OpenVPN Status Monitor</title>'.format(settings['site'])
     print '<meta http-equiv="refresh" content="300" />'
 
     if maps:
@@ -465,9 +462,9 @@ def html_header(settings, vpns, maps):
     print '</button>'
 
     if 'logo' in settings:
-        print '<a href="#" class="pull-left"><img alt="logo" style="max-height:50px; padding-right: 10px" src="%s"></a>' % settings['logo']
+        print '<a href="#" class="pull-left"><img alt="logo" style="max-height:50px; padding-right: 10px" src="{0!s}"></a>'.format(settings['logo'])
 
-    print '<a class="navbar-brand" href="#">%s OpenVPN Status Monitor</a>' % settings['site']
+    print '<a class="navbar-brand" href="#">{0!s} OpenVPN Status Monitor</a>'.format(settings['site'])
     print '</div><div class="collapse navbar-collapse" id="myNavbar">'
     print '<ul class="nav navbar-nav"><li class="dropdown">'
     print '<a class="dropdown-toggle" data-toggle="dropdown" href="#">VPN<span class="caret"></span></a>'
@@ -476,7 +473,7 @@ def html_header(settings, vpns, maps):
     for key, vpn in vpns:
         if vpn['name']:
             anchor = vpn['name'].lower().replace(' ', '_')
-            print '<li><a href="#%s">%s</a></li>' % (anchor, vpn['name'])
+            print '<li><a href="#{0!s}">{1!s}</a></li>'.format(anchor, vpn['name'])
 
     print '</ul></li><li><a href="#map_canvas">Map View</a></li></ul></div></div></nav>'
     print '<div class="container-fluid">'
@@ -527,21 +524,20 @@ def main(args):
             openvpn_print_html(vpn)
         else:
             anchor = vpn['name'].lower().replace(' ', '_')
-            print '<div class="panel panel-danger" id="%s">' % anchor
+            print '<div class="panel panel-danger" id="{0!s}">'.format(anchor)
             print '<div class="panel-heading">'
-            print '<h3 class="panel-title">%s</h3></div>' % vpn['name']
+            print '<h3 class="panel-title">{0!s}</h3></div>'.format(vpn['name'])
             print '<div class="panel-body">'
-            print 'Connection refused to %s:%s </div></div>' % \
-                (vpn['host'], vpn['port'])
+            print 'Connection refused to {0!s}:{1!s} </div></div>'.format(vpn['host'], vpn['port'])
 
     if maps:
         google_maps_html()
 
     if debug:
-        print "=== begin vpns\n%s\n=== end vpns" % vpns
+        print "=== begin vpns\n{0!s}\n=== end vpns".format(vpns)
 
-    print '<div class="well">Page automatically reloads every 5 minutes. Last update: <b>%s</b></div>' % \
-        datetime.now().strftime('%a %d/%m/%Y %H:%M:%S')
+    print '<div class="well">Page automatically reloads every 5 minutes. Last update: <b>{0!s}</b></div>'.format( \
+        datetime.now().strftime('%a %d/%m/%Y %H:%M:%S'))
     print '</div></body></html>'
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:furlongm:openvpn-monitor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:furlongm:openvpn-monitor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)