### PR TITLE
Fix falling back to the certificate common name when no username is set.

### DIFF
--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -322,7 +322,7 @@ class OpenvpnMonitor(object):
                     if parts[8] != 'UNDEF':
                         session['username'] = parts[8]
                     else:
-                        session['username'] = parts[0]
+                        session['username'] = parts[1]
                     if parts[2].count(':') == 1:
                         remote_ip, port = parts[2].split(':')
                     else:


### PR DESCRIPTION
Currently the session username will be set to the literal string 'CLIENT_LIST' if there is no username. This fixes that by continuing to try Username first, then falling back to the Common Name if that isn't set.