### PR TITLE
support for unix socket

### DIFF
--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -201,7 +201,9 @@ class OpenvpnMgmtInterface(object):
                 self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 self.s.connect(vpn['socket'])
             else:
-                self.s = socket.create_connection((vpn['host'],int(vpn['port'])), timeout)
+                host = vpn['host']
+                port = int(vpn['port'])
+                self.s = socket.create_connection((host, port), timeout)
             if self.s:
                 vpn['socket_connected'] = True
                 data = ''

--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -194,12 +194,14 @@ class OpenvpnMgmtInterface(object):
             return self.s.recv(length).decode('utf-8')
 
     def _socket_connect(self, vpn):
-        host = vpn['host']
-        port = int(vpn['port'])
         timeout = 3
         self.s = False
         try:
-            self.s = socket.create_connection((host, port), timeout)
+            if 'socket' in vpn:
+                self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.s.connect(vpn['socket'])
+            else:
+                self.s = socket.create_connection((vpn['host'],int(vpn['port'])), timeout)
             if self.s:
                 vpn['socket_connected'] = True
                 data = ''


### PR DESCRIPTION
If the "socket" option is defined in the config file, it will take
precedence over "host" and "port" and the script will attempt to connect
to the management interface using that socket.