### PR TITLE
added geoip2 support

### DIFF
--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -25,7 +25,11 @@ except ImportError:
 import socket
 import re
 import argparse
-import geoip2.database
+try:
+  import geoip2.database
+except ImportError:
+  # No geoip2 support
+  pass
 import GeoIP
 import sys
 import os

--- a/openvpn-monitor.py
+++ b/openvpn-monitor.py
@@ -26,10 +26,10 @@ import socket
 import re
 import argparse
 try:
-  import geoip2.database
+    import geoip2.database
 except ImportError:
-  # No geoip2 support
-  pass
+    # No geoip2 support
+    pass
 import GeoIP
 import sys
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 GeoIP==1.3.2
+geoip2==2.7.0
 humanize==0.5.1
 ipaddr==2.2.0; python_version <= '2.7'
 six==1.11.0


### PR DESCRIPTION
With this patch, it is possible to use the new geoip format (see "https://dev.maxmind.com/geoip/geoip2/geolite2/"). The lookups seem slower, but the data is more accurate.

If the db file specified by the config parameter "geoip_data" has extension ".mmdb", geoip2 is used instead of GeoIP.