### PR TITLE
Added content type for PyPI long description to fix markdown rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     py_modules=['openvpn-monitor', ],
     install_requires=install_requires,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     data_files=data_files,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Default PyPI formatting is reStructuredText and must be explicitly told to use markdown, see https://packaging.python.org/specifications/core-metadata/#description-content-type-optional