### PR TITLE
Fix logo null handling and URL routing

### DIFF
--- a/openvpn_monitor/app.py
+++ b/openvpn_monitor/app.py
@@ -170,6 +170,9 @@ def openvpn_monitor_wsgi():
     @app.route('/images/logo', methods=['GET'])
     def get_logo():
         logo = settings.get('logo')
+        if not logo:
+            logging.warning('No logo defined in settings')
+            return '', 204
         if logo.startswith('http'):
             logging.info(f'Using `{logo}` for logo (http link)')
             return logo
@@ -183,6 +186,7 @@ def openvpn_monitor_wsgi():
             logging.info(f'Using `{logo_file}` for logo (static)')
             return current_app.send_static_file(static_logo)
         logging.error(f'Logo defined but image not found, skipping')
+        return '', 404
 
     @app.route('/', methods=['GET', 'POST'])
     def handle_root():

--- a/openvpn_monitor/templates/navbar.html
+++ b/openvpn_monitor/templates/navbar.html
@@ -24,7 +24,7 @@
     </ul>
       {% if logo %}
         <a href="#" class="pull-right">
-          <img alt="Logo" style="max-height:46px; padding-top:3px;" src="images/logo">
+          <img alt="Logo" style="max-height:46px; padding-top:3px;" src="{{ url_for('get_logo') }}">
         </a>
       {% endif %}
     </div>


### PR DESCRIPTION
Guard against logo being None/empty to prevent AttributeError on
startswith(). Return 404 when logo file is not found instead of
returning None. Use url_for('get_logo') in template instead of
relative path which breaks when app is mounted at a sub-path.
