### PR TITLE
Fix disconnector crash on None address

### DIFF
--- a/openvpn_monitor/vpns/openvpn/disconnector.py
+++ b/openvpn_monitor/vpns/openvpn/disconnector.py
@@ -49,9 +49,10 @@ class VPNDisconnector(object):
                 logging.info(f'[{name}] Disconnecting client id `{client_id}`')
                 command = f'client-kill {client_id}'
             else:
-                ip = ip_address(kwargs.get('ip'))
+                ip_str = kwargs.get('ip')
                 port = kwargs.get('port')
-                if ip and port:
+                if ip_str and port:
+                    ip = ip_address(ip_str)
                     logging.info(f'[{name}] Disconnecting client `{ip}:{port}`')
                     command = f'kill {ip}:{port}'
             if command:


### PR DESCRIPTION
ip_address(None) raises TypeError. Check that ip and port are present
before calling ip_address().
