### PR TITLE
Show hostname alongside username in session display

### DIFF
--- a/openvpn_monitor/templates/server_session.html
+++ b/openvpn_monitor/templates/server_session.html
@@ -4,6 +4,7 @@
 {% set bytes_recv = session.get('bytes_recv') %}
 {% set bytes_sent = session.get('bytes_sent') %}
 {% set username = session.get('username') %}
+{% set hostname = session.get('hostname') %}
 {% set local_ip = session.get('local_ip') %}
 {% set remote_ip = session.get('remote_ip') %}
 {% set port = session.get('port') %}
@@ -11,7 +12,7 @@
 {% set location = session.get('location') %}
 {% set full_location = session | get_full_location %}
 {% set flag = session | get_flag %}
-<td>{{ username }}</td>
+<td>{% if hostname %}{{ username }} / {{ hostname }}{% else %}{{ username }}{% endif %}</td>
 <td>{{ local_ip }}</td>
 <td>{{ remote_ip }}</td>
 {% if location %}

--- a/openvpn_monitor/vpns/openvpn/data_collector.py
+++ b/openvpn_monitor/vpns/openvpn/data_collector.py
@@ -191,6 +191,8 @@ class VPNDataCollector(object):
                     session['username'] = username
                 else:
                     session['username'] = common_name
+                if common_name and common_name != username:
+                    session['hostname'] = common_name
                 if version >= semver.Version.parse('2.4.0'):
                     session['client_id'] = parts.popleft()
                     session['peer_id'] = parts.popleft()


### PR DESCRIPTION
When common_name differs from username, store it as hostname and
display as 'username / hostname' in the session table.
