### PR TITLE
add ipv6 dual-stack support

### DIFF
--- a/openvpn_monitor/templates/server_session.html
+++ b/openvpn_monitor/templates/server_session.html
@@ -1,11 +1,12 @@
 {% set connected_since = session.get('connected_since').strftime(datetime_format) %}
-{% set last_seen = session.get('last_seen').strftime(datetime_format) %}
+{% set last_seen = session.get('last_seen').strftime(datetime_format) if session.get('last_seen') else None %}
 {% set total_connected_time = session.get('connected_since') | get_total_connected_time %}
 {% set bytes_recv = session.get('bytes_recv') %}
 {% set bytes_sent = session.get('bytes_sent') %}
 {% set username = session.get('username') %}
 {% set hostname = session.get('hostname') %}
 {% set local_ip = session.get('local_ip') %}
+{% set local_ipv6 = session.get('local_ipv6') %}
 {% set remote_ip = session.get('remote_ip') %}
 {% set port = session.get('port') %}
 {% set client_id = session.get('client_id') %}
@@ -13,7 +14,7 @@
 {% set full_location = session | get_full_location %}
 {% set flag = session | get_flag %}
 <td>{% if hostname %}{{ username }} / {{ hostname }}{% else %}{{ username }}{% endif %}</td>
-<td>{{ local_ip }}</td>
+<td>{% if local_ipv6 %}{{ local_ip }}<br>{{ local_ipv6 }}{% else %}{{ local_ip }}{% endif %}</td>
 <td>{{ remote_ip }}</td>
 {% if location %}
 <td><img src="{{ url_for('static', filename=flag) }}" title="{{ full_location }}" alt="{{ full_location }}">&nbsp;{{ full_location }}</td>

--- a/openvpn_monitor/templates/vpn_info.html
+++ b/openvpn_monitor/templates/vpn_info.html
@@ -10,6 +10,7 @@
 {% set vpn_mode = vpn.get('state').get('mode') %}
 {% set sessions = vpn.get('sessions', {}).items()  %}
 {% set local_ip = vpn.get('state').get('local_ip') %}
+{% set local_ipv6 = vpn.get('state').get('local_ipv6') %}
 {% set remote_ip = vpn.get('state').get('remote_ip') %}
 {% set up_since = vpn.get('state').get('up_since') %}
 {% set show_disconnect = vpn.get('show_disconnect') %}
@@ -46,7 +47,7 @@
             <td>{{ bytesin }} ({{ bytesin | get_naturalsize }})</td>
             <td>{{ bytesout }} ({{ bytesout | get_naturalsize }})</td>
             <td>{{ up_since.strftime(datetime_format) }}</td>
-            <td>{{ local_ip }}</td>
+            <td>{% if local_ipv6 %}{{ local_ip }}<br>{{ local_ipv6 }}{% else %}{{ local_ip }}{% endif %}</td>
             {% if vpn_mode == 'Client' %}
             <td>{{ remote_ip }}</td>
             {% endif %}

--- a/openvpn_monitor/vpns/openvpn/data_collector.py
+++ b/openvpn_monitor/vpns/openvpn/data_collector.py
@@ -72,14 +72,22 @@ class VPNDataCollector(object):
                 state['up_since'] = get_date(date_string=parts[0], uts=True)
                 state['connected'] = parts[1]
                 state['success'] = parts[2]
-                if parts[3]:
-                    state['local_ip'] = ip_address(parts[3])
-                else:
+                try:
+                    if parts[3]:
+                        state['local_ip'] = ip_address(parts[3])
+                    else:
+                        state['local_ip'] = ''
+                    if parts[4]:
+                        state['remote_ip'] = ip_address(parts[4])
+                        state['mode'] = 'Client'
+                    else:
+                        state['remote_ip'] = ''
+                        state['mode'] = 'Server'
+                    if len(parts) > 8 and parts[8]:
+                        state['local_ipv6'] = ip_address(parts[8])
+                except (ValueError, IndexError) as e:
+                    logging.warning(f'Error parsing state IP addresses: {e}')
                     state['local_ip'] = ''
-                if parts[4]:
-                    state['remote_ip'] = ip_address(parts[4])
-                    state['mode'] = 'Client'
-                else:
                     state['remote_ip'] = ''
                     state['mode'] = 'Server'
         return state
@@ -171,8 +179,8 @@ class VPNDataCollector(object):
                             session['latitude'] = gir.location.latitude
                     except AddressNotFoundError as e:
                         logging.warning(e)
-                    except SystemError:
-                        pass
+                    except SystemError as e:
+                        logging.warning(f'SystemError during GeoIP lookup: {e}')
                 local_ipv4 = parts.popleft()
                 if local_ipv4:
                     session['local_ip'] = ip_address(local_ipv4)
@@ -181,7 +189,7 @@ class VPNDataCollector(object):
                 if version >= semver.Version.parse('2.4.0'):
                     local_ipv6 = parts.popleft()
                     if local_ipv6:
-                        session['local_ip'] = ip_address(local_ipv6)
+                        session['local_ipv6'] = ip_address(local_ipv6)
                 session['bytes_recv'] = int(parts.popleft())
                 session['bytes_sent'] = int(parts.popleft())
                 parts.popleft()
@@ -200,12 +208,24 @@ class VPNDataCollector(object):
 
             if routes_section:
                 local_ip = parts[1]
-                remote_ip = parts[3]
-                route_remote, route_port, _ = self.parse_remote_address(remote_ip)
+                route_remote, route_port, _ = self.parse_remote_address(parts[3])
                 route_address = self.get_remote_address(route_remote, route_port)
                 last_seen = get_date(parts[5], uts=True)
+                # Match by IPv4 key, or find session whose local_ipv6 matches
+                matched_key = None
                 if sessions.get(local_ip):
-                    sessions[local_ip]['last_seen'] = last_seen
+                    matched_key = local_ip
+                else:
+                    for s_key, s_val in sessions.items():
+                        if str(s_val.get('local_ipv6', '')) == local_ip:
+                            matched_key = s_key
+                            break
+                if matched_key:
+                    if sessions[matched_key].get('last_seen'):
+                        if sessions[matched_key]['last_seen'] < last_seen:
+                            sessions[matched_key]['last_seen'] = last_seen
+                    else:
+                        sessions[matched_key]['last_seen'] = last_seen
                 elif self.is_mac_address(local_ip):
                     matching_local_ips = [sessions[s]['local_ip']
                                           for s in sessions if route_address ==


### PR DESCRIPTION
Store ipv6 address in separate local_ipv6 field instead of overwriting local_ip, which is used as the session key.

Match ipv6 routing table entries by scanning sessions for matching local_ipv6.

Capture ipv6 local address from state command (parts[8]) for openvvpn 2.7+.

Display both addresses in templates.

Guard last_seen against None when routes haven't been matched yet.

Log SystemError during geoip lookups instead of silently swallowing.
